### PR TITLE
🔒 [security fix] Fix Markdown injection in crate and category generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tracing = "0.1.44"
 url = "2.5.8"
 walkdir = "2.5.0"
-tempfile = "3.13"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src/generate/crates.rs
+++ b/src/generate/crates.rs
@@ -36,7 +36,10 @@ pub fn generate_categories<P1: AsRef<Path> + std::fmt::Debug, P2: AsRef<Path> + 
                 path = &path[..path.len() - 1];
             }
             if let Some(name) = path.split('/').next_back() {
-                if !name.is_empty() && name != "categories" {
+                if !name.is_empty()
+                    && name != "categories"
+                    && name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+                {
                     categories.insert(name.to_string());
                 }
             }
@@ -74,7 +77,10 @@ pub fn generate_crates<P1: AsRef<Path> + std::fmt::Debug, P2: AsRef<Path> + std:
                 path = &path[..path.len() - 1];
             }
             if let Some(name) = path.split('/').next_back() {
-                if !name.is_empty() && name != "crates" {
+                if !name.is_empty()
+                    && name != "crates"
+                    && name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+                {
                     crates.insert(name.to_string());
                 }
             }
@@ -213,6 +219,53 @@ mod test {
 
         let content = std::fs::read_to_string(&dest_file)?;
         let expected = "# Crates\n\n";
+        assert_eq!(content, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_crates_injection() -> Result<()> {
+        let dir = tempdir()?;
+        let src_dir = dir.path().join("src");
+        fs::create_dir(&src_dir)?;
+
+        let md1 = src_dir.join("1.md");
+        fs::write(
+            &md1,
+            "Malicious crate: [crate](https://crates.io/crates/mycrate](javascript:alert(1))/).",
+        )?;
+
+        let dest_file = dir.path().join("crates.md");
+        generate_crates(&src_dir, &dest_file)?;
+
+        let content = fs::read_to_string(&dest_file)?;
+        // If vulnerable, it would contain: - [mycrate](javascript:alert(1))](https://crates.io/crates/mycrate](javascript:alert(1)))
+        // After fix, it should skip it or sanitize it.
+        // Given our planned fix is to skip it, we expect no crates.
+        let expected = "# Crates\n\n";
+        assert_eq!(content, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_categories_injection() -> Result<()> {
+        let dir = tempdir()?;
+        let src_dir = dir.path().join("src");
+        fs::create_dir(&src_dir)?;
+
+        let md1 = src_dir.join("1.md");
+        fs::write(
+            &md1,
+            "Malicious category: [cat](https://crates.io/categories/mycat](javascript:alert(1))/).",
+        )?;
+
+        let dest_file = dir.path().join("categories.md");
+        generate_categories(&src_dir, &dest_file)?;
+
+        let content = fs::read_to_string(&dest_file)?;
+        let expected = "# Categories\n\n";
         assert_eq!(content, expected);
 
         Ok(())


### PR DESCRIPTION
🎯 **What:** Markdown injection vulnerability in crate and category generation logic.

⚠️ **Risk:** Maliciously crafted URLs in source Markdown files could lead to the generation of broken or malicious Markdown links (e.g., containing `javascript:` URIs) in the output index files, potentially affecting anyone viewing the generated documentation.

🛡️ **Solution:** Implemented a strict character whitelist for crate and category names extracted from URLs. Only alphanumeric characters, hyphens, and underscores are allowed. Any name containing other characters is skipped. Also fixed a duplicate dependency in `Cargo.toml` that was preventing the build.

---
*PR created automatically by Jules for task [17570615208649602638](https://jules.google.com/task/17570615208649602638) started by @john-cd*