### PR TITLE
🧪 Add edge case tests for generate_sitemap URL validation

### DIFF
--- a/src/api/sitemap.rs
+++ b/src/api/sitemap.rs
@@ -69,3 +69,28 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use url::Url;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_generate_sitemap_invalid_base_url() {
+        let markdown_src_dir_path = PathBuf::from("non_existent_src");
+        let base_url = Url::parse("mailto:test@example.com").unwrap();
+        let sitemap_dest_file_path = PathBuf::from("sitemap.xml");
+        let map_index = None;
+
+        let result = generate_sitemap(
+            markdown_src_dir_path,
+            base_url,
+            sitemap_dest_file_path,
+            map_index,
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid URL - cannot be a base"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -925,4 +925,27 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_generate_sitemap_invalid_base_url() {
+        use std::path::PathBuf;
+        use url::Url;
+        let markdown_src_dir_path = PathBuf::from("non_existent_src");
+        let base_url = Url::parse("mailto:test@example.com").unwrap();
+        let sitemap_dest_file_path = PathBuf::from("sitemap.xml");
+        let map_index = None;
+
+        let result = generate_sitemap(
+            markdown_src_dir_path,
+            base_url,
+            sitemap_dest_file_path,
+            map_index,
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid URL - cannot be a base"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -928,11 +928,13 @@ mod test {
 
     #[test]
     fn test_generate_sitemap_invalid_base_url() {
-        use std::path::PathBuf;
         use url::Url;
-        let markdown_src_dir_path = PathBuf::from("non_existent_src");
+
+        let dir = tempdir().unwrap();
+        let markdown_src_dir_path = dir.path().join("src");
+        fs::create_dir(&markdown_src_dir_path).unwrap();
         let base_url = Url::parse("mailto:test@example.com").unwrap();
-        let sitemap_dest_file_path = PathBuf::from("sitemap.xml");
+        let sitemap_dest_file_path = dir.path().join("sitemap.xml");
         let map_index = None;
 
         let result = generate_sitemap(


### PR DESCRIPTION
🎯 **What:** Missing edge case tests for `generate_sitemap` URL validation, specifically for URLs that "cannot be a base".

📊 **Coverage:** Added a test case `test_generate_sitemap_invalid_base_url` to both redundant implementations of `generate_sitemap` (in `src/api/sitemap.rs` and `src/lib.rs`). The test validates that passing a 'cannot-be-a-base' URL (e.g., `mailto:`) returns the expected error "Invalid URL - cannot be a base".

✨ **Result:** Improved reliability and coverage of the sitemap generation API by ensuring invalid base URLs are correctly identified and handled, preventing potential downstream errors.

---
*PR created automatically by Jules for task [5816761245277086292](https://jules.google.com/task/5816761245277086292) started by @john-cd*