### PR TITLE
⚡ [optimize generate_sitemap by avoiding redundant PathBuf clone]

### DIFF
--- a/src/api/sitemap.rs
+++ b/src/api/sitemap.rs
@@ -56,7 +56,7 @@ where
 
     let summary_md_path = markdown_src_dir_path.join("SUMMARY.md");
     tracing::debug!("SUMMARY.md path: {}", summary_md_path.display());
-    let markdown = std::fs::read_to_string(summary_md_path.clone()).with_context(|| {
+    let markdown = std::fs::read_to_string(&summary_md_path).with_context(|| {
         format!(
             "[generate_sitemap] Could not read {}. Does the file exist?",
             summary_md_path.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ where
 
     let summary_md_path = markdown_src_dir_path.join("SUMMARY.md");
     tracing::debug!("SUMMARY.md path: {}", summary_md_path.display());
-    let markdown = std::fs::read_to_string(summary_md_path.clone()).with_context(|| {
+    let markdown = std::fs::read_to_string(&summary_md_path).with_context(|| {
         format!(
             "[generate_sitemap] Could not read {}. Does the file exist?",
             summary_md_path.display()


### PR DESCRIPTION
💡 **What:** 
Removed redundant `.clone()` calls on `PathBuf` when invoking `std::fs::read_to_string` in the `generate_sitemap` function. This change was applied to both `src/api/sitemap.rs` and `src/lib.rs` to maintain consistency across redundant implementations.

🎯 **Why:** 
`std::fs::read_to_string` accepts `P: AsRef<Path>`, so it can take a reference to a `PathBuf` without requiring ownership. Cloning the `PathBuf` creates an unnecessary heap allocation and string copy. By using a reference, we avoid this overhead while still keeping the original `PathBuf` available for the error-handling closure in `.with_context()`.

📊 **Measured Improvement:** 
As this optimization avoids a single heap allocation per call to `generate_sitemap`, the performance impact is micro-architectural. In the context of a tool that performs disk I/O (reading `SUMMARY.md` and writing `sitemap.xml`), the time saved is negligible compared to I/O latency. However, it follows Rust best practices for avoiding unnecessary allocations and improves code idiomaticity. No statistically significant macro-benchmark results were expected or obtained due to the dominance of I/O operations and environment restrictions.

---
*PR created automatically by Jules for task [11415790288636723090](https://jules.google.com/task/11415790288636723090) started by @john-cd*