### PR TITLE
🧹 Add Sync trait bound to generic path parameters

### DIFF
--- a/src/markdown/remove_includes.rs
+++ b/src/markdown/remove_includes.rs
@@ -37,7 +37,7 @@ pub fn remove_includes_in_all_markdown_files_in<P>(
     contents_to_insert: &str,
 ) -> Result<Vec<std::path::PathBuf>>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + std::marker::Sync,
 {
     let modified = Mutex::new(Vec::new());
 


### PR DESCRIPTION
The task was to add `std::marker::Sync` trait bound to generic types used as paths (like `P` or `P2`) when they are used in concurrent contexts (specifically with `rayon`).

Upon analysis, I found that:
1. `src/markdown/extract_code.rs` already had the `Sync` bound for `P2` in its functions.
2. `src/markdown/replace_include.rs` already had the `Sync` bound for `P`.
3. `src/markdown/remove_includes.rs` was missing the `Sync` bound for its generic parameter `P`, which is used in a parallel iterator.

I have updated `src/markdown/remove_includes.rs` to include the necessary `Sync` trait bound.

🎯 What: Added `+ std::marker::Sync` to the generic parameter `P` in `src/markdown/remove_includes.rs`.
💡 Why: Required for thread safety when the generic type is captured by closures in `rayon` parallel iterators.
✅ Verification: Manually verified the file content and reviewed against existing patterns in the codebase. `cargo check` and `cargo test` were attempted but skipped due to restricted network access in the environment, following project guidelines for such cases.

---
*PR created automatically by Jules for task [2272994002207154174](https://jules.google.com/task/2272994002207154174) started by @john-cd*