### PR TITLE
🧪 [add unit tests for write_duplicate_links]

### DIFF
--- a/src/api/links.rs
+++ b/src/api/links.rs
@@ -169,4 +169,40 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_write_duplicate_links() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let src_dir = temp_dir.path().join("src");
+        fs::create_dir(&src_dir)?;
+
+        let md_file_path1 = src_dir.join("test1.md");
+        fs::write(
+            &md_file_path1,
+            "Link 1: [example1](http://example.com/1)\nLink 2: [example2](http://example.com/2)\n",
+        )?;
+
+        let md_file_path2 = src_dir.join("test2.md");
+        fs::write(
+            &md_file_path2,
+            "Link 1 again: [example1](http://example.com/1)\nLink 3: [example3](http://example.com/3)\n",
+        )?;
+
+        let dest_file_path = temp_dir.path().join("duplicate_links.md");
+
+        write_duplicate_links(&src_dir, &dest_file_path)?;
+
+        assert!(dest_file_path.exists());
+        let content = fs::read_to_string(&dest_file_path)?;
+
+        assert!(content.contains("# Duplicate Links"));
+
+        let occurrences = content.matches("http://example.com/1").count();
+        assert_eq!(occurrences, 2);
+
+        assert!(!content.contains("http://example.com/2"));
+        assert!(!content.contains("http://example.com/3"));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the `write_duplicate_links` function which identifies and reports duplicate HTTP links across markdown files.
📊 **Coverage:** Added a test scenario that creates multiple markdown files with shared and unique links, verifying that only shared links are reported in the output and that they are recorded for each occurrence.
✨ **Result:** Improved reliability of the duplicate link detection logic and ensured that future changes to this function will be validated against expected behavior.

---
*PR created automatically by Jules for task [5202911850838509724](https://jules.google.com/task/5202911850838509724) started by @john-cd*