### PR TITLE
🔒 [security fix] Path Traversal via Late Validation in extract_code

### DIFF
--- a/src/fs/path_validation.rs
+++ b/src/fs/path_validation.rs
@@ -7,18 +7,61 @@ use anyhow::bail;
 
 /// Returns the canonicalized path if it is within the canonicalized base_dir.
 /// Otherwise returns an error.
+///
+/// This function handles non-existent files by validating their parent directory.
+/// Dangling symlinks are rejected for security.
 pub(crate) fn is_path_within(base_dir: &Path, path: &Path) -> Result<PathBuf> {
     let base_dir_canon = base_dir.canonicalize()?;
-    let path_canon = path.canonicalize()?;
 
-    if path_canon.starts_with(&base_dir_canon) {
-        Ok(path_canon)
-    } else {
-        bail!(
-            "Path traversal detected: {:?} is outside of {:?}",
-            path_canon,
-            base_dir_canon
-        );
+    match path.canonicalize() {
+        Ok(path_canon) => {
+            if path_canon.starts_with(&base_dir_canon) {
+                Ok(path_canon)
+            } else {
+                bail!(
+                    "Path traversal detected: {:?} is outside of {:?}",
+                    path_canon,
+                    base_dir_canon
+                );
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // If the path doesn't exist, it might be a dangling symlink or a new file.
+            // Check if it's a dangling symlink.
+            if path.symlink_metadata().is_ok() {
+                bail!("Path traversal detected: {:?} is a dangling symlink", path);
+            }
+
+            // Find the first existing ancestor
+            let mut ancestor = path;
+            while let Some(parent) = ancestor.parent() {
+                ancestor = parent;
+                // If parent is empty string (relative path in current dir), use "."
+                let effective_ancestor = if ancestor.as_os_str().is_empty() {
+                    Path::new(".")
+                } else {
+                    ancestor
+                };
+
+                if let Ok(ancestor_canon) = effective_ancestor.canonicalize() {
+                    if ancestor_canon.starts_with(&base_dir_canon) {
+                        // The ancestor is safe.
+                        // We return the path as is if it's within base_dir_canon.
+                        // Note: starts_with on non-canonicalized paths can be tricked,
+                        // but here we are just validating safety.
+                        return Ok(path.to_path_buf());
+                    } else {
+                        bail!(
+                            "Path traversal detected: ancestor {:?} is outside of {:?}",
+                            ancestor_canon,
+                            base_dir_canon
+                        );
+                    }
+                }
+            }
+            bail!("Path traversal detected: {:?} has no existing ancestor within base directory", path);
+        }
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -34,7 +77,7 @@ mod test {
     fn test_is_path_within() -> Result<()> {
         let dir = tempdir()?;
         let base_dir = dir.path().join("base");
-        fs::create_dir(&base_dir)?;
+        fs::create_dir_all(&base_dir)?;
 
         let safe_file = base_dir.join("safe.txt");
         fs::write(&safe_file, "safe")?;
@@ -42,11 +85,27 @@ mod test {
         let unsafe_file = dir.path().join("unsafe.txt");
         fs::write(&unsafe_file, "unsafe")?;
 
-        // Positive case
+        // Positive case: existing file
         assert!(is_path_within(&base_dir, &safe_file).is_ok());
 
-        // Negative case
+        // Negative case: existing file outside
         assert!(is_path_within(&base_dir, &unsafe_file).is_err());
+
+        // Positive case: non-existent file in safe dir
+        let non_existent_safe = base_dir.join("new.txt");
+        assert!(is_path_within(&base_dir, &non_existent_safe).is_ok());
+
+        // Negative case: non-existent file in unsafe dir
+        let non_existent_unsafe = dir.path().join("new_unsafe.txt");
+        assert!(is_path_within(&base_dir, &non_existent_unsafe).is_err());
+
+        // Negative case: dangling symlink (even if it points to a safe location, we reject it)
+        #[cfg(unix)]
+        {
+            let dangling = base_dir.join("dangling.lnk");
+            std::os::unix::fs::symlink(base_dir.join("non_existent"), &dangling)?;
+            assert!(is_path_within(&base_dir, &dangling).is_err());
+        }
 
         Ok(())
     }

--- a/src/markdown/extract_code.rs
+++ b/src/markdown/extract_code.rs
@@ -81,10 +81,6 @@ where
                 );
                 let code_path = code_dest_dir_path.as_ref().join(code_filename);
 
-                // create the file before canonicalizing the full path, otherwise canonicalize fails
-                if !code_path.exists() {
-                    File::create(&code_path)?;
-                }
                 if crate::fs::is_path_within(&code_dest_canon, &code_path).is_err() {
                     anyhow::bail!("Path traversal detected: attempt to write file outside destination directory");
                 }


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `extract_code_from_all_markdown_files_in`.
⚠️ **Risk:** The previous code created files before validating their paths. An attacker could use symlinks or traversal paths to truncate or overwrite files outside the destination directory.
🛡️ **Solution:** Moved `is_path_within` validation to occur before any filesystem modifications. Improved `is_path_within` to handle non-existent files and nested directories by validating ancestors and rejecting dangling symlinks.

---
*PR created automatically by Jules for task [15112469026205517324](https://jules.google.com/task/15112469026205517324) started by @john-cd*